### PR TITLE
Wifi signal percentage device class

### DIFF
--- a/airlytix-es1.yaml
+++ b/airlytix-es1.yaml
@@ -417,6 +417,7 @@ sensor:
       - lambda: return min(max(2 * (x + 100.0), 0.0), 100.0);
     unit_of_measurement: "%"
     entity_category: "diagnostic"
+    device_class: ""
 
   - platform: sound_level
     id: ambient_sound_level


### PR DESCRIPTION
Closes #29 

Based on https://esphome.io/components/sensor/wifi_signal/

I just wonder why in the above example they have:

```
unit_of_measurement: "Signal %"
```

this is a bit weird, and I'd say just `%` should be ok here?